### PR TITLE
2.20 - officer system for private ship

### DIFF
--- a/Bot_NetCore/Commands/PrivateCommands.cs
+++ b/Bot_NetCore/Commands/PrivateCommands.cs
@@ -366,7 +366,7 @@ namespace Bot_NetCore.Commands
             var ship = PrivateShip.GetOwnedShip(ctx.Member.Id);
             if (ship == null)
             {
-                await ctx.RespondAsync($"{Bot.BotSettings.ErrorEmoji} Ты не являешься владельцем корабля");
+                await ctx.RespondAsync($"{Bot.BotSettings.ErrorEmoji} Ты не являешься капитаном корабля");
                 return;
             }
 
@@ -388,7 +388,7 @@ namespace Bot_NetCore.Commands
             shipMember.Role = PrivateShipMemberRole.Officer;
             try
             {
-                await member.SendMessageAsync($":pilot: Ты был назначен офицером на корабле **{ship.Name}**");
+                await member.SendMessageAsync($":arrow_up: Ты был назначен офицером на корабле **{ship.Name}**");
             }
             catch (UnauthorizedException)
             {
@@ -396,6 +396,45 @@ namespace Bot_NetCore.Commands
             }
 
             await ctx.RespondAsync($"{Bot.BotSettings.OkEmoji} Участник был успешно назначен офицером");
+        }
+        
+        [Command("demote")]
+        [Description("Назначает пользователя офицером")]
+        public async Task Demote(CommandContext ctx, [Description("Офицер")] DiscordMember member)
+        {
+            var ship = PrivateShip.GetOwnedShip(ctx.Member.Id);
+            if (ship == null)
+            {
+                await ctx.RespondAsync($"{Bot.BotSettings.ErrorEmoji} Ты не являешься капитаном корабля");
+                return;
+            }
+
+            // check if the specified member is a ship member
+            var shipMember = ship.GetMember(member.Id);
+            if (shipMember == null || !shipMember.Status)
+            {
+                await ctx.RespondAsync($"{Bot.BotSettings.ErrorEmoji} Этого участника нет на корабле");
+                return;
+            }
+            
+            // check if the specified member is not an officer 
+            if (shipMember.Role != PrivateShipMemberRole.Officer)
+            {
+                await ctx.RespondAsync($"{Bot.BotSettings.ErrorEmoji} Участник не является офицером");
+                return;
+            }
+
+            shipMember.Role = PrivateShipMemberRole.Officer;
+            try
+            {
+                await member.SendMessageAsync($":arrow_down: Ты был снят с должности офицера на корабле **{ship.Name}**");
+            }
+            catch (UnauthorizedException)
+            {
+                
+            }
+
+            await ctx.RespondAsync($"{Bot.BotSettings.OkEmoji} Участник был снят с должности офицера");
         }
         
         /* Секция для админ-команд */

--- a/Bot_NetCore/Commands/PrivateCommands.cs
+++ b/Bot_NetCore/Commands/PrivateCommands.cs
@@ -107,7 +107,7 @@ namespace Bot_NetCore.Commands
             try
             {
                 await member.SendMessageAsync(
-                    $"Ты был приглашён присоединиться к кораблю **{ship.Name}**. Используй в канале для команд " +
+                    $":envelope: Ты был приглашён присоединиться к кораблю **{ship.Name}**. Используй в канале для команд " +
                     $"`!p yes {ship.Name}`, чтобы принять приглашение, или `!p no {ship.Name}`, чтобы отклонить его.");
             }
             catch (UnauthorizedException)
@@ -303,11 +303,11 @@ namespace Bot_NetCore.Commands
                 if (selected.Status)
                 {
                     await ctx.Guild.GetChannel(ship.Channel).AddOverwriteAsync(member);
-                    await member.SendMessageAsync($"{title} **{ctx.Member.DisplayName}#{ctx.Member.Discriminator}** " +
+                    await member.SendMessageAsync($":right_facing_fist: {title} **{ctx.Member.DisplayName}#{ctx.Member.Discriminator}** " +
                                                   $"выгнал тебя с корабля **{ship.Name}**");
                 }
                 else
-                    await member.SendMessageAsync($"{title} **{ctx.Member.DisplayName}#{ctx.Member.Discriminator}** " +
+                    await member.SendMessageAsync($":right_facing_fist: {title} **{ctx.Member.DisplayName}#{ctx.Member.Discriminator}** " +
                                                   $"отменил твоё приглашение на корабль **{ship.Name}**");
             }
             catch (UnauthorizedException)
@@ -409,7 +409,7 @@ namespace Bot_NetCore.Commands
             await ctx.RespondAsync($"{Bot.BotSettings.OkEmoji} Ты успешно передал должность капитана");
             try
             {
-                await member.SendMessageAsync($"Ты был назначен капитаном корабля **{ship.Name}**");
+                await member.SendMessageAsync($":crown: Ты был назначен капитаном корабля **{ship.Name}**");
                 return;
             }
             catch (UnauthorizedException)

--- a/Bot_NetCore/Commands/PrivateCommands.cs
+++ b/Bot_NetCore/Commands/PrivateCommands.cs
@@ -106,12 +106,33 @@ namespace Bot_NetCore.Commands
 
         [Command("list")]
         [Description("Отправляет список членов вашего корабля")]
-        public async Task List(CommandContext ctx)
+        public async Task List(CommandContext ctx, [Description("Название корабля (необязательно для капитанов)")][RemainingText] string shipName = null)
         {
-            var ship = PrivateShip.GetOwnedShip(ctx.Member.Id);
-            if (ship == null)
+            PrivateShip ship = null;
+            if (string.IsNullOrEmpty(shipName))
             {
-                await ctx.RespondAsync($"{Bot.BotSettings.ErrorEmoji} Вы не являетесь владельцем корабля!");
+                ship = PrivateShip.GetOwnedShip(ctx.Member.Id);
+                if (ship == null)
+                {
+                    await ctx.RespondAsync($"{Bot.BotSettings.ErrorEmoji} Ты не являешься капитаном");
+                    return;
+                }
+            }
+            else
+            {
+                ship = PrivateShip.Get(shipName);
+                if (ship == null)
+                {
+                    await ctx.RespondAsync($"{Bot.BotSettings.ErrorEmoji} Указанный корабль не был найден!");
+                    return;
+                }
+            }
+
+            var requesterMember = ship.GetMember(ctx.Member.Id);
+            if (requesterMember == null ||
+                (requesterMember.Role != PrivateShipMemberRole.Officer && requesterMember.Role != PrivateShipMemberRole.Captain))
+            {
+                await ctx.RespondAsync($"{Bot.BotSettings.ErrorEmoji} Ты не являешься офицером или капитаном на данном корабле");
                 return;
             }
 

--- a/Bot_NetCore/Commands/PrivateCommands.cs
+++ b/Bot_NetCore/Commands/PrivateCommands.cs
@@ -359,6 +359,45 @@ namespace Bot_NetCore.Commands
             }
         }
 
+        [Command("promote")]
+        [Description("Назначает пользователя офицером")]
+        public async Task Promote(CommandContext ctx, [Description("Новый офицер")] DiscordMember member)
+        {
+            var ship = PrivateShip.GetOwnedShip(ctx.Member.Id);
+            if (ship == null)
+            {
+                await ctx.RespondAsync($"{Bot.BotSettings.ErrorEmoji} Ты не являешься владельцем корабля");
+                return;
+            }
+
+            // check if the specified member is a ship member
+            var shipMember = ship.GetMember(member.Id);
+            if (shipMember == null || !shipMember.Status)
+            {
+                await ctx.RespondAsync($"{Bot.BotSettings.ErrorEmoji} Нельзя назначить офицером пользователя, которого нет на корабле");
+                return;
+            }
+            
+            // check if the specified member is not an officer already
+            if (shipMember.Role == PrivateShipMemberRole.Officer)
+            {
+                await ctx.RespondAsync($"{Bot.BotSettings.ErrorEmoji} Пользователь уже является офицером");
+                return;
+            }
+
+            shipMember.Role = PrivateShipMemberRole.Officer;
+            try
+            {
+                await member.SendMessageAsync($":pilot: Ты был назначен офицером на корабле **{ship.Name}**");
+            }
+            catch (UnauthorizedException)
+            {
+                
+            }
+
+            await ctx.RespondAsync($"{Bot.BotSettings.OkEmoji} Участник был успешно назначен офицером");
+        }
+        
         /* Секция для админ-команд */
 
         [Command("fdelete")]

--- a/Bot_NetCore/Commands/PrivateCommands.cs
+++ b/Bot_NetCore/Commands/PrivateCommands.cs
@@ -134,7 +134,7 @@ namespace Bot_NetCore.Commands
 
                 var type = PrivateShipMember.RoleEnumToStringRu(member.Role);
 
-                memberList.Add($"{type} {discordMember.DisplayName}#{discordMember.Discriminator}.");
+                memberList.Add($"{type} {discordMember.DisplayName}#{discordMember.Discriminator}." + (member.Status ? null : " Приглашён."));
             }
 
             var interactivity = ctx.Client.GetInteractivity();

--- a/Bot_NetCore/Commands/PrivateCommands.cs
+++ b/Bot_NetCore/Commands/PrivateCommands.cs
@@ -96,6 +96,14 @@ namespace Bot_NetCore.Commands
                 }
             }
             
+            var requesterMember = ship.GetMember(ctx.Member.Id);
+            if (requesterMember == null ||
+                (requesterMember.Role != PrivateShipMemberRole.Officer && requesterMember.Role != PrivateShipMemberRole.Captain))
+            {
+                await ctx.RespondAsync($"{Bot.BotSettings.ErrorEmoji} Ты не являешься офицером или капитаном на данном корабле");
+                return;
+            }
+            
             if (ship.GetMembers().Any(m => m.MemberId == member.Id))
             {
                 await ctx.RespondAsync(

--- a/Bot_NetCore/Commands/PrivateCommands.cs
+++ b/Bot_NetCore/Commands/PrivateCommands.cs
@@ -424,7 +424,7 @@ namespace Bot_NetCore.Commands
                 return;
             }
 
-            shipMember.Role = PrivateShipMemberRole.Officer;
+            shipMember.Role = PrivateShipMemberRole.Member;
             try
             {
                 await member.SendMessageAsync($":arrow_down: Ты был снят с должности офицера на корабле **{ship.Name}**");

--- a/Bot_NetCore/Entities/PrivateShip.cs
+++ b/Bot_NetCore/Entities/PrivateShip.cs
@@ -352,6 +352,14 @@ namespace Bot_NetCore.Entities
         }
 
         /// <summary>
+        ///     Returns a member with the specified ID or null.
+        /// </summary>
+        public PrivateShipMember GetMember(ulong memberId)
+        {
+            return PrivateShipMember.Get(_name, memberId);
+        }
+
+        /// <summary>
         ///     Adds a new member to a private ship and saves him to the database.
         /// </summary>
         /// <param name="id">ID of a member</param>

--- a/Bot_NetCore/Entities/PrivateShipMember.cs
+++ b/Bot_NetCore/Entities/PrivateShipMember.cs
@@ -101,7 +101,7 @@ namespace Bot_NetCore.Entities
             {
                 using (var cmd = new MySqlCommand())
                 {
-                    cmd.CommandText = "SELECT * FROM private_ship WHERE ship_name = @ship AND member_id = @member";
+                    cmd.CommandText = "SELECT * FROM private_ship_members WHERE ship_name = @ship AND member_id = @member;";
                     cmd.Parameters.AddWithValue("@ship", ship);
                     cmd.Parameters.AddWithValue("@member", memberId);
                     cmd.Connection = connection;

--- a/Bot_NetCore/Entities/PrivateShipMember.cs
+++ b/Bot_NetCore/Entities/PrivateShipMember.cs
@@ -93,6 +93,31 @@ namespace Bot_NetCore.Entities
         }
 
         /// <summary>
+        ///     Gets a ship member with the specified ID.
+        /// </summary>
+        public static PrivateShipMember Get(string ship, ulong memberId)
+        {
+            using (var connection = new MySqlConnection(Bot.ConnectionString))
+            {
+                using (var cmd = new MySqlCommand())
+                {
+                    cmd.CommandText = "SELECT * FROM private_ship WHERE ship_name = @ship AND member_id = @member";
+                    cmd.Parameters.AddWithValue("@ship", ship);
+                    cmd.Parameters.AddWithValue("@member", memberId);
+                    cmd.Connection = connection;
+                    cmd.Connection.Open();
+
+                    var reader = cmd.ExecuteReader();
+                    if (!reader.Read())
+                        return null;
+                    else
+                        return new PrivateShipMember(ship, reader.GetUInt64(1),
+                            StringEnumToRoleEnum(reader.GetString(2)), reader.GetString(3) == "Active");
+                }
+            }
+        }
+
+        /// <summary>
         ///     Gets members of the specified ship. Use PrivateShip.GetMembers() to avoid errors.
         /// </summary>
         /// <returns>Members of the specified ship</returns>
@@ -112,7 +137,7 @@ namespace Bot_NetCore.Entities
                     while (reader.Read())
                     {
                         result.Add(new PrivateShipMember(ship, reader.GetUInt64(1),
-                            StringEnumToRoleEnum(reader.GetString(2)), reader.GetString(3) == "Active" ? true : false));
+                            StringEnumToRoleEnum(reader.GetString(2)), reader.GetString(3) == "Active"));
                     }
 
                     return result;


### PR DESCRIPTION
**Новые функции**
• Капитаны могут назначать офицеров на своих приватных кораблях с помощью команды `!p promote ЧЛЕН КОРАБЛЯ` и снимать их с должности с помощью команды `!p demote ОФИЦЕР`.
• Офицеры могут просматривать список членов экипажа, приглашать и выгонять участников.

**Изменения**
• Поскольку участник может быть офицером на нескольких кораблях были изменены команды `!p invite УЧАСТНИК`, `!p kick УЧАСТНИК`, `!p list`: в конце команды офицеры должны указать название корабля (например, `!p list Пентхаус`). Для капитанов команды остались прежними.